### PR TITLE
feat(step-6): Bridge MCP tools with LangChain4j

### DIFF
--- a/src/main/java/com/example/agent/config/LangChainConfig.java
+++ b/src/main/java/com/example/agent/config/LangChainConfig.java
@@ -1,9 +1,9 @@
 package com.example.agent.config;
 
 import com.example.agent.agent.BacklogAgent;
+import com.example.agent.tools.AgentTool;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.service.AiServices;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,14 +27,8 @@ public class LangChainConfig {
                 .build();
     }
 
-    /**
-     * ObjectProvider allows Spring to inject all AgentTool beans if they exist (STEP 6+),
-     * or an empty list if none are registered yet.
-     */
     @Bean
-    public BacklogAgent backlogAgent(AnthropicChatModel model, ObjectProvider<Object> toolsProvider) {
-        List<Object> tools = toolsProvider.stream().toList();
-
+    public BacklogAgent backlogAgent(AnthropicChatModel model, List<AgentTool> tools) {
         System.out.println("=== Agent tools loaded: " + tools.size() + " ===");
         tools.forEach(t -> System.out.println(" - " + t.getClass().getName()));
 

--- a/src/main/java/com/example/agent/tools/AgentTool.java
+++ b/src/main/java/com/example/agent/tools/AgentTool.java
@@ -1,0 +1,4 @@
+package com.example.agent.tools;
+
+public interface AgentTool {
+}

--- a/src/main/java/com/example/agent/tools/GitHubMcpTools.java
+++ b/src/main/java/com/example/agent/tools/GitHubMcpTools.java
@@ -1,0 +1,40 @@
+package com.example.agent.tools;
+
+import com.example.agent.mcp.McpHttpClient;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class GitHubMcpTools implements AgentTool {
+
+    private final McpHttpClient mcp;
+    private final String owner;
+    private final String repo;
+
+    public GitHubMcpTools(
+            McpHttpClient mcp,
+            @Value("${github.owner}") String owner,
+            @Value("${github.repo}") String repo
+    ) {
+        this.mcp = mcp;
+        this.owner = owner;
+        this.repo = repo;
+    }
+
+    @Tool("Create a GitHub issue in the configured repository. Use when the user asks to create a task/issue.")
+    public String createIssue(
+            @P("Issue title") String title,
+            @P("Issue body in Markdown") String body
+    ) {
+        Map result = (Map) mcp.callTool(
+                "create_issue",
+                Map.of("owner", owner, "repo", repo, "title", title, "body", body)
+        ).block();
+
+        return "Issue created successfully: " + result;
+    }
+}


### PR DESCRIPTION
## Summary
- Create `AgentTool` marker interface
- Create `GitHubMcpTools` with `@Tool createIssue()` delegating to `McpHttpClient`
- Update `LangChainConfig` to inject `List<AgentTool>` into `AiServices` builder

Closes #7

## Test plan
- [x] `./gradlew clean test` passes
- [x] CI green