### PR TITLE
test(step-8): Add unit tests for MCP bridge

### DIFF
--- a/src/test/java/com/example/agent/tools/GitHubMcpToolsTest.java
+++ b/src/test/java/com/example/agent/tools/GitHubMcpToolsTest.java
@@ -1,14 +1,45 @@
 package com.example.agent.tools;
 
-import org.junit.jupiter.api.Disabled;
+import com.example.agent.mcp.McpHttpClient;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
-// TODO STEP 8 — activate when McpHttpClient and GitHubMcpTools are implemented (STEP 5 & 6)
-@Disabled("Waiting for STEP 5 (McpHttpClient) and STEP 6 (GitHubMcpTools)")
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
 class GitHubMcpToolsTest {
 
     @Test
-    void should_call_mcp_tool() {
-        // will be implemented in STEP 8
+    void should_call_mcp_tool_and_return_success_message() {
+        McpHttpClient mcp = mock(McpHttpClient.class);
+        when(mcp.callTool(eq("create_issue"), anyMap()))
+                .thenReturn(Mono.just(Map.of("number", 42, "html_url", "https://github.com/owner/repo/issues/42")));
+
+        GitHubMcpTools tools = new GitHubMcpTools(mcp, "owner", "repo");
+        String result = tools.createIssue("Test title", "Test body");
+
+        assertTrue(result.contains("Issue created successfully"));
+        verify(mcp, times(1)).callTool(eq("create_issue"), anyMap());
+    }
+
+    @Test
+    void should_pass_owner_repo_title_body_to_mcp() {
+        McpHttpClient mcp = mock(McpHttpClient.class);
+        when(mcp.callTool(anyString(), anyMap()))
+                .thenReturn(Mono.just(Map.of("number", 1)));
+
+        GitHubMcpTools tools = new GitHubMcpTools(mcp, "my-owner", "my-repo");
+        tools.createIssue("My title", "My body");
+
+        verify(mcp).callTool(eq("create_issue"), argThat(args ->
+                "my-owner".equals(args.get("owner")) &&
+                "my-repo".equals(args.get("repo")) &&
+                "My title".equals(args.get("title")) &&
+                "My body".equals(args.get("body"))
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Activate `GitHubMcpToolsTest` (was `@Disabled`)
- Test 1: `createIssue()` returns "Issue created successfully"
- Test 2: `owner`/`repo`/`title`/`body` correctly passed to `McpHttpClient`
- `McpHttpClient` mocked with Mockito — no real HTTP call

Closes #9

## Test plan
- [x] 4 tests total pass: `contextLoads`, `should_create_and_get_user`, `should_call_mcp_tool_and_return_success_message`, `should_pass_owner_repo_title_body_to_mcp`
- [x] `./gradlew clean test` green
- [x] CI green