### PR TITLE
feat(step-10): Dockerize the agent

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+build
+bin
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Stage 1: Build
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+
+RUN chmod +x gradlew && ./gradlew --no-daemon clean bootJar -x test
+
+# Stage 2: Runtime
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+RUN addgroup -S spring && adduser -S spring -G spring
+USER spring
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- Multi-stage `Dockerfile`: builder (JDK 21 alpine) + runtime (JRE 21 alpine)
- Non-root user `spring` for security
- `.dockerignore` to exclude `.git`, `build/`, `bin/`
- Exposes port `8080`

Closes #11

## Test plan
- [x] `./gradlew bootJar` produces the jar
- [x] `docker build` succeeds (requires Docker)
- [x] CI green
