### PR TITLE
ci(step-11): Setup CI/CD with Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,21 @@ jobs:
 
       - name: Build & Test
         run: ./gradlew --no-daemon clean test
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: lab-mcp-ai-agent:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add `docker-build` job to CI, runs after `build-test`
- Uses `docker/build-push-action` with `push: false` — validates the image builds without pushing to a registry
- GitHub Actions layer cache (`type=gha`) for performance
- Existing `build-test` job unchanged

Closes #12

## Test plan
- [x] `build-test` job: `./gradlew clean test` green
- [x] `docker-build` job: image builds successfully
- [x] CI green on push to any branch