### PR TITLE
feat(step-13): Kubernetes smoke test on Minikube in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,46 @@ jobs:
           tags: lab-mcp-ai-agent:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  kubernetes:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Start Minikube
+        uses: medyagh/setup-minikube@master
+
+      - name: Build Docker image in Minikube
+        run: |
+          eval $(minikube docker-env)
+          docker build -t ai-agent:dev .
+
+      - name: Create namespace and secrets
+        run: |
+          kubectl create namespace lab-agent
+          kubectl create secret generic agent-secrets \
+            --from-literal=ANTHROPIC_API_KEY=ci-stub \
+            --from-literal=GITHUB_TOKEN=ci-stub \
+            -n lab-agent
+
+      - name: Deploy AI agent
+        run: |
+          kubectl apply -f k8s/ai-agent.yaml
+          kubectl set env deployment/ai-agent SPRING_PROFILES_ACTIVE=ci -n lab-agent
+
+      - name: Wait for deployment
+        run: kubectl rollout status deployment/ai-agent -n lab-agent --timeout=120s
+
+      - name: Test actuator health
+        run: |
+          kubectl port-forward svc/ai-agent 8080:8080 -n lab-agent &
+          sleep 5
+          curl --fail http://localhost:8080/actuator/health

--- a/k8s/ai-agent.yaml
+++ b/k8s/ai-agent.yaml
@@ -23,12 +23,34 @@ spec:
                 secretKeyRef:
                   name: agent-secrets
                   key: ANTHROPIC_API_KEY
+            - name: GITHUB_OWNER
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: GITHUB_OWNER
+            - name: GITHUB_REPO
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: GITHUB_REPO
             - name: MCP_BASE_URL
               value: "http://github-mcp-server:3333"
             - name: MCP_PATH
               value: "/mcp"
           ports:
             - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service

--- a/src/main/java/com/example/agent/config/CiChatModelConfig.java
+++ b/src/main/java/com/example/agent/config/CiChatModelConfig.java
@@ -1,0 +1,26 @@
+package com.example.agent.config;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("ci")
+public class CiChatModelConfig {
+
+    @Bean
+    public ChatModel chatModel() {
+        return new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest request) {
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("CI stub response"))
+                        .build();
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/agent/config/LangChainConfig.java
+++ b/src/main/java/com/example/agent/config/LangChainConfig.java
@@ -3,10 +3,12 @@ package com.example.agent.config;
 import com.example.agent.agent.BacklogAgent;
 import com.example.agent.tools.AgentTool;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.AiServices;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.time.Duration;
 import java.util.List;
@@ -15,7 +17,8 @@ import java.util.List;
 public class LangChainConfig {
 
     @Bean
-    public AnthropicChatModel anthropicChatModel(
+    @Profile("!ci")
+    public ChatModel anthropicChatModel(
             @Value("${anthropic.api-key}") String apiKey,
             @Value("${anthropic.model}") String model,
             @Value("${anthropic.timeout-seconds:60}") Integer timeoutSeconds
@@ -28,7 +31,7 @@ public class LangChainConfig {
     }
 
     @Bean
-    public BacklogAgent backlogAgent(AnthropicChatModel model, List<AgentTool> tools) {
+    public BacklogAgent backlogAgent(ChatModel model, List<AgentTool> tools) {
         System.out.println("=== Agent tools loaded: " + tools.size() + " ===");
         tools.forEach(t -> System.out.println(" - " + t.getClass().getName()));
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,12 @@ anthropic:
 mcp:
   base-url: ${MCP_BASE_URL:http://localhost:3333}
   path: ${MCP_PATH:/mcp}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always

--- a/src/test/java/com/example/agent/AgentApplicationTests.java
+++ b/src/test/java/com/example/agent/AgentApplicationTests.java
@@ -1,7 +1,7 @@
 package com.example.agent;
 
 import com.example.agent.agent.BacklogAgent;
-import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.chat.ChatModel;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -12,7 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 class AgentApplicationTests {
 
 	@MockBean
-	AnthropicChatModel anthropicChatModel;
+	ChatModel chatModel;
 
 	@MockBean
 	BacklogAgent backlogAgent;

--- a/src/test/java/com/example/agent/web/AgentControllerIT.java
+++ b/src/test/java/com/example/agent/web/AgentControllerIT.java
@@ -1,7 +1,7 @@
 package com.example.agent.web;
 
 import com.example.agent.agent.BacklogAgent;
-import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.chat.ChatModel;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 class AgentControllerIT {
 
     @MockBean
-    AnthropicChatModel anthropicChatModel;
+    ChatModel chatModel;
 
     @MockBean
     BacklogAgent backlogAgent;

--- a/src/test/java/com/example/agent/web/UserControllerIT.java
+++ b/src/test/java/com/example/agent/web/UserControllerIT.java
@@ -2,7 +2,7 @@ package com.example.agent.web;
 
 import com.example.agent.domain.User;
 import com.example.agent.agent.BacklogAgent;
-import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.chat.ChatModel;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class UserControllerIT {
 
     @MockBean
-    AnthropicChatModel anthropicChatModel;
+    ChatModel chatModel;
 
     @MockBean
     BacklogAgent backlogAgent;


### PR DESCRIPTION
- Add spring-boot-starter-actuator, expose /actuator/health
- Add CiChatModelConfig: stub ChatModel for profile=ci
- Add @Profile("!ci") on AnthropicChatModel bean in LangChainConfig
- Add readiness/liveness probes on /actuator/health in k8s/ai-agent.yaml
- Add GITHUB_OWNER/GITHUB_REPO env vars in k8s/ai-agent.yaml
- Add kubernetes CI job: Minikube setup, docker build, deploy with SPRING_PROFILES_ACTIVE=ci, wait for rollout, curl /actuator/health
- Update tests: MockBean ChatModel (not AnthropicChatModel) to match new bean return type

Closes #26